### PR TITLE
Bump vector upper bound

### DIFF
--- a/src/Data/Vector/Instances.hs
+++ b/src/Data/Vector/Instances.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 -----------------------------------------------------------------------------
@@ -25,8 +26,13 @@ import Data.Pointed
 import Data.Monoid (Monoid(..))
 import qualified Data.Vector as Vector
 import qualified Data.Vector.Generic as G
+#if MIN_VERSION_vector(0,11,0)
+import qualified Data.Vector.Fusion.Bundle as Stream
+import Data.Vector.Fusion.Bundle.Size
+#else
 import qualified Data.Vector.Fusion.Stream as Stream
 import Data.Vector.Fusion.Stream.Size
+#endif
 import Data.Vector (Vector,(++),drop,length,imap,ifoldr, ifoldl, izipWith,(!?),(//), generate)
 import qualified Data.Vector as Vector
 import qualified Data.Vector.Unboxed as Unboxed

--- a/vector-instances.cabal
+++ b/vector-instances.cabal
@@ -28,7 +28,7 @@ library
   hs-source-dirs: src
   build-depends:
     base          >= 4       && < 5,
-    vector        >= 0.9     && < 0.11,
+    vector        >= 0.9     && < 0.12,
     semigroupoids >= 3,
     semigroups    >= 0.8.3.1,
     comonad       >= 3,


### PR DESCRIPTION
This is only non-trivial due to the renaming of `Data.Vector.Fusion.Stream` to `Data.Vector.Fusion.Bundle`. This brought with it representational changes as well since the `Stream` type is now `Bundle` (which allow for chunked operations) but type inference allows us to get away with ignoring this.