### PR TITLE
Hashable1 instance

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -78,36 +78,6 @@ jobs:
             compilerVersion: 8.0.2
             setup-method: hvr-ppa
             allow-failure: false
-          - compiler: ghc-7.10.3
-            compilerKind: ghc
-            compilerVersion: 7.10.3
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-7.8.4
-            compilerKind: ghc
-            compilerVersion: 7.8.4
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-7.6.3
-            compilerKind: ghc
-            compilerVersion: 7.6.3
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-7.4.2
-            compilerKind: ghc
-            compilerVersion: 7.4.2
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-7.2.2
-            compilerKind: ghc
-            compilerVersion: 7.2.2
-            setup-method: hvr-ppa
-            allow-failure: true
-          - compiler: ghc-7.0.4
-            compilerKind: ghc
-            compilerVersion: 7.0.4
-            setup-method: hvr-ppa
-            allow-failure: true
       fail-fast: false
     steps:
       - name: apt

--- a/src/Data/Vector/Instances.hs
+++ b/src/Data/Vector/Instances.hs
@@ -21,6 +21,9 @@ import Data.Semigroup
 #ifdef MIN_VERSION_hashable
 import Data.Hashable (Hashable(..))
 #endif
+#if MIN_VERSION_hashable(1,2,5)
+import Data.Hashable.Lifted (Hashable1(..))
+#endif
 import Data.Key
 import Data.Functor.Bind
 import Data.Functor.Extend
@@ -149,4 +152,10 @@ instance (Storable.Storable a, Hashable a) => Hashable (Storable.Vector a) where
 instance (Primitive.Prim a, Hashable a) => Hashable (Primitive.Vector a) where
   hashWithSalt salt = hashWithSalt salt . Primitive.toList
   {-# INLINE hashWithSalt #-}
+#endif
+
+#if MIN_VERSION_hashable(1,2,5)
+instance Hashable1 Vector where
+  liftHashWithSalt itemHashWithSalt salt = liftHashWithSalt itemHashWithSalt salt . Vector.toList
+  {-# INLINE liftHashWithSalt #-}
 #endif

--- a/src/Data/Vector/Instances.hs
+++ b/src/Data/Vector/Instances.hs
@@ -20,8 +20,6 @@ import Control.Monad
 import Data.Semigroup
 #ifdef MIN_VERSION_hashable
 import Data.Hashable (Hashable(..))
-#endif
-#if MIN_VERSION_hashable(1,2,5)
 import Data.Hashable.Lifted (Hashable1(..))
 #endif
 import Data.Key
@@ -152,9 +150,7 @@ instance (Storable.Storable a, Hashable a) => Hashable (Storable.Vector a) where
 instance (Primitive.Prim a, Hashable a) => Hashable (Primitive.Vector a) where
   hashWithSalt salt = hashWithSalt salt . Primitive.toList
   {-# INLINE hashWithSalt #-}
-#endif
 
-#if MIN_VERSION_hashable(1,2,5)
 instance Hashable1 Vector where
   liftHashWithSalt itemHashWithSalt salt = liftHashWithSalt itemHashWithSalt salt . Vector.toList
   {-# INLINE liftHashWithSalt #-}

--- a/vector-instances.cabal
+++ b/vector-instances.cabal
@@ -12,12 +12,6 @@ category:            Data, Data Structures
 build-type:          Simple
 cabal-version:       >=1.10
 tested-with:
-  GHC==7.0.4,
-  GHC==7.2.2,
-  GHC==7.4.2,
-  GHC==7.6.3,
-  GHC==7.8.4,
-  GHC==7.10.3,
   GHC==8.0.2,
   GHC==8.2.2,
   GHC==8.4.4,
@@ -51,8 +45,8 @@ library
   exposed-modules: Data.Vector.Instances
   hs-source-dirs: src
   build-depends:
-    base          >= 4       && < 5,
-    vector        >= 0.9     && < 0.14,
+    base          >= 4.9     && < 5,
+    vector        >= 0.12    && < 0.14,
     semigroupoids >= 3,
     semigroups    >= 0.8.3.1,
     comonad       >= 3,

--- a/vector-instances.cabal
+++ b/vector-instances.cabal
@@ -60,4 +60,4 @@ library
     keys          >= 3
 
   if flag(hashable)
-    build-depends:  hashable >= 1.1.1.0
+    build-depends:  hashable >= 1.2.5.0


### PR DESCRIPTION
Adds `instance Hashable1 Vector`.

`Hashable1` was added to `hashable` in version 1.2.5.0 ([changelog](https://hackage.haskell.org/package/hashable-1.3.2.0/changelog#version-1250)).