### PR TITLE
Remove redundant dependency on semigroups

### DIFF
--- a/vector-instances.cabal
+++ b/vector-instances.cabal
@@ -47,7 +47,6 @@ library
     base          >= 4.9     && < 5,
     vector        >= 0.12    && < 0.14,
     semigroupoids >= 3,
-    semigroups    >= 0.8.3.1,
     comonad       >= 3,
     pointed       >= 3,
     keys          >= 3


### PR DESCRIPTION
It's only needed for GHC < 8 which isn't present in the tested-with array.